### PR TITLE
Start quiz endpoint implemented

### DIFF
--- a/src/main/java/co/com/quisofka/quizzes/domain/model/quiz/enums/Status.java
+++ b/src/main/java/co/com/quisofka/quizzes/domain/model/quiz/enums/Status.java
@@ -2,6 +2,7 @@ package co.com.quisofka.quizzes.domain.model.quiz.enums;
 
 public enum Status {
     GENERATED,
+    STARTED,
     FINISHED
 
 }

--- a/src/main/java/co/com/quisofka/quizzes/domain/model/quiz/gateways/QuizRepositoryGateway.java
+++ b/src/main/java/co/com/quisofka/quizzes/domain/model/quiz/gateways/QuizRepositoryGateway.java
@@ -14,4 +14,5 @@ public interface QuizRepositoryGateway {
     Mono<Quiz> createSecondLvlQuiz(Quiz quiz);
     Mono<Quiz> createThirdLvlQuiz(Quiz quiz);
     Mono<Void> deleteAll();
+    Mono<Quiz> startQuiz(String id);
 }

--- a/src/main/java/co/com/quisofka/quizzes/domain/usecase/quiz/StartQuiz/StartQuizUseCase.java
+++ b/src/main/java/co/com/quisofka/quizzes/domain/usecase/quiz/StartQuiz/StartQuizUseCase.java
@@ -1,0 +1,19 @@
+package co.com.quisofka.quizzes.domain.usecase.quiz.StartQuiz;
+
+import co.com.quisofka.quizzes.domain.model.quiz.Quiz;
+import co.com.quisofka.quizzes.domain.model.quiz.gateways.QuizRepositoryGateway;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Function;
+
+@RequiredArgsConstructor
+public class StartQuizUseCase implements Function<String, Mono<Quiz>> {
+
+    private final QuizRepositoryGateway repositoryGateway;
+
+    @Override
+    public Mono<Quiz> apply(String id) {
+        return this.repositoryGateway.startQuiz(id);
+    }
+}

--- a/src/main/java/co/com/quisofka/quizzes/infrastructure/entryPoints/RouterRestQuiz.java
+++ b/src/main/java/co/com/quisofka/quizzes/infrastructure/entryPoints/RouterRestQuiz.java
@@ -1,6 +1,7 @@
 package co.com.quisofka.quizzes.infrastructure.entryPoints;
 
 import co.com.quisofka.quizzes.domain.model.quiz.Quiz;
+import co.com.quisofka.quizzes.domain.usecase.quiz.StartQuiz.StartQuizUseCase;
 import co.com.quisofka.quizzes.domain.usecase.quiz.createFirstLvlQuiz.CreateFirstLvlQuizUseCase;
 import co.com.quisofka.quizzes.domain.usecase.quiz.createQuiz.CreateQuizUseCase;
 import co.com.quisofka.quizzes.domain.usecase.quiz.createSecondLvlQuiz.CreateSecondLvlQuizUseCase;
@@ -49,13 +50,13 @@ public class RouterRestQuiz {
 
 
     @Bean
-    public RouterFunction<ServerResponse> getQuestionById(GetQuizByIdUseCase getQuizByIdUseCase){
+    public RouterFunction<ServerResponse> getQuizById(GetQuizByIdUseCase getQuizByIdUseCase){
         return route(GET("/quisofka/quizzes/quizzes/{id}"),
                 request -> getQuizByIdUseCase.apply(request.pathVariable("id"))
                         .switchIfEmpty(Mono.error(new Throwable(HttpStatus.NO_CONTENT.toString())))
-                        .flatMap(question -> ServerResponse.status(200)
+                        .flatMap(quiz -> ServerResponse.status(200)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .bodyValue(question))
+                                .bodyValue(quiz))
                         .onErrorResume(throwable -> ServerResponse.notFound().build()));
     }
 
@@ -129,6 +130,18 @@ public class RouterRestQuiz {
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .bodyValue(result))
                                 .onErrorResume(throwable -> ServerResponse.status(HttpStatus.NOT_ACCEPTABLE).bodyValue(throwable.getMessage()))));
+    }
+
+
+    @Bean
+    public RouterFunction<ServerResponse> startQuiz(StartQuizUseCase startQuizUseCase){
+        return route(PATCH("/quisofka/quizzes/quizzes/start/{id}"),
+                request -> startQuizUseCase.apply(request.pathVariable("id"))
+                        .switchIfEmpty(Mono.error(new Throwable(HttpStatus.NO_CONTENT.toString())))
+                        .flatMap(quiz -> ServerResponse.status(200)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .bodyValue(quiz))
+                        .onErrorResume(throwable -> ServerResponse.notFound().build()));
     }
 
 


### PR DESCRIPTION
STARTED was added in the status quiz enum, and the use case and gateway were implemented, adapter and router were also implemented. The endpoint uses a PATCH method to update the quiz entity and it only receives the quiz id in the url.